### PR TITLE
Relax version constraints for torch dependencies

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -11,7 +11,7 @@ repos:
         - id: isort
 
   - repo: https://github.com/python/black
-    rev: 20.8b1
+    rev: 22.3.0
     hooks:
         - id: black
           language_version: python3

--- a/ezflow/functional/criterion/multiscale.py
+++ b/ezflow/functional/criterion/multiscale.py
@@ -84,7 +84,7 @@ class MultiScaleLoss(nn.Module):
 
             elif self.norm == "robust":
                 loss_value = (real_flow - label).abs().sum(dim=1) + 1e-8
-                loss_value = loss_value ** 0.4
+                loss_value = loss_value**0.4
 
             elif self.norm == "l1":
                 loss_value = (real_flow - label).abs().sum(dim=1)

--- a/ezflow/functional/criterion/sequence.py
+++ b/ezflow/functional/criterion/sequence.py
@@ -41,7 +41,7 @@ class SequenceLoss(nn.Module):
         flow, valid = label[:, :2, :, :], label[:, 2:, :, :]
         valid = torch.squeeze(valid, dim=1)
 
-        mag = torch.sqrt(torch.sum(flow ** 2, dim=1))
+        mag = torch.sqrt(torch.sum(flow**2, dim=1))
         valid = (valid >= 0.5) & (mag < self.max_flow)
 
         for i in range(n_preds):

--- a/ezflow/similarity/correlation/pairwise.py
+++ b/ezflow/similarity/correlation/pairwise.py
@@ -54,7 +54,7 @@ class MutliScalePairwise4DCorr:
             dy = torch.linspace(-r, r, 2 * r + 1)
             delta = torch.stack(torch.meshgrid(dy, dx), axis=-1).to(coords.device)
 
-            centroid_lvl = coords.reshape(batch * h1 * w1, 1, 1, 2) / 2 ** i
+            centroid_lvl = coords.reshape(batch * h1 * w1, 1, 1, 2) / 2**i
             delta_lvl = delta.view(1, 2 * r + 1, 2 * r + 1, 2)
             coords_lvl = centroid_lvl + delta_lvl
 

--- a/ezflow/utils/io.py
+++ b/ezflow/utils/io.py
@@ -118,7 +118,7 @@ def read_flow_png(filename):
     flow = cv2.imread(filename, cv2.IMREAD_ANYDEPTH | cv2.IMREAD_COLOR)
     flow = flow[:, :, ::-1].astype(np.float32)
     flow, valid = flow[:, :, :2], flow[:, :, 2]
-    flow = (flow - 2 ** 15) / 64.0
+    flow = (flow - 2**15) / 64.0
     return flow, valid
 
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -103,9 +103,9 @@ termcolor==1.1.0
 text-unidecode==1.3
 toml 
 tomli==1.2.1
-torch==1.9.0
-torchmetrics==0.5.0
-torchvision==0.10.0
+torch>=1.9.0
+torchmetrics>=0.5.0
+torchvision>=0.10.0
 tornado 
 tox==3.14.0
 tqdm 


### PR DESCRIPTION
On platforms like Colab, PyTorch and its related packages are usually pre-installed. If we have specific versions of torch packages as dependencies, then it leads to the existing versions being uninstalled and the specified versions installed. I think we can relax the version constraints for these packages.